### PR TITLE
 Add batch_truevalue field

### DIFF
--- a/controllers/batchController.js
+++ b/controllers/batchController.js
@@ -9,6 +9,7 @@ const AddBatch = async (req, res) => {
     manufacture_date,
     exp_date,
     quantity,
+    batch_truevalue,
   } = req.body;
   try {
     const newBatch = await ItemBatch.create({
@@ -19,6 +20,7 @@ const AddBatch = async (req, res) => {
       manufacture_date,
       exp_date,
       quantity,
+      batch_truevalue,
     });
     res.status(201).json(newBatch);
   } catch (error) {
@@ -36,6 +38,7 @@ const UpdateBatch = async (req, res) => {
     manufacture_date,
     exp_date,
     quantity,
+    batch_truevalue,
   } = req.body;
   try {
     const updatedBatch = await ItemBatch.update(
@@ -47,6 +50,7 @@ const UpdateBatch = async (req, res) => {
         manufacture_date,
         exp_date,
         quantity,
+        batch_truevalue,
       },
       { where: { batch_id: id } }
     );

--- a/models/itemBatch.js
+++ b/models/itemBatch.js
@@ -36,6 +36,10 @@ module.exports = (sequelize) => {
       quantity: {
         type: DataTypes.DECIMAL(10, 2),
         allowNull: false,
+      },
+      batch_truevalue: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: true,
       }, // 🟢 enables createdAt and updatedAt
     },
     {


### PR DESCRIPTION
Adds the `batch_truevalue` field to the `Item_batches` model. This field is a DECIMAL(10, 2) and can be null.

The `AddBatch` and `UpdateBatch` controller functions in `batchController.js` have been updated to handle this new field.
- `AddBatch` now includes `batch_truevalue` when creating a new batch.
- `UpdateBatch` now includes `batch_truevalue` when updating an existing batch.

The API routes remain unchanged as the controller handles the new field. Getter functions (`GetBatch`, `GetAllBatches`, `GetBatchByItem`) will automatically include the new field in their responses.